### PR TITLE
Change gdown id

### DIFF
--- a/docs/source/usage_cluster.rst
+++ b/docs/source/usage_cluster.rst
@@ -55,7 +55,7 @@ Download the DeepPrep sif image from Google Drive
 
     $ cd <shared_storage_path>
 
-    $ gdown --id  1iqopJLSsXaFLHZnNQsQuASXnkfUT62UO
+    $ gdown --id  1SFDWjRRdF-C1w_C9XzS6KJKdMWaJc0zW
 
 Then you will get: ``<shared_storage_path>/deepprep_23.1.0.sif``
 


### PR DESCRIPTION
The provided gdown command didn't work for me.
I changed the gdown id based on the Google Drive URL, and it worked and downloaded `deepprep_23.1.0.sif` properly.